### PR TITLE
Improve: 协作指南中发起 PR 的流程

### DIFF
--- a/文档及代码协作指南.md
+++ b/文档及代码协作指南.md
@@ -85,6 +85,7 @@ QQ 群的时效性、随意性较强，难以翻查每个人提出的意见，�
 
 1. 从 [git 官网](https://git-scm.com/) 上下载 Git for Windows，并以默认选项安装。
 1. 熟悉 Git Bash。Git for Windows 自带 `Git Bash` `Git CMD` `Git GUI` 三种用户界面。在本次课程设计中，我们只使用 `Git Bash`。在实际进行 Git 相关操作以前，熟悉 `Git Bash` 并调整的字体大小以及默认窗口大小满意自己喜好。
+1. 生成 SSH Key 并添加到自己的 GitHub 帐号中，具体的步骤参见 [廖雪峰的 Git 教程/远程仓库](http://www.liaoxuefeng.com/wiki/0013739516305929606dd18361248578c67b8067c8c017b000/001374385852170d9c7adf13c30429b9660d0eb689dd43a000)。
 1. 使用 VS Code 新建文件 `C:\Users\<your-win-username>\.gitconfig`，并填入如下内容：
 
 	在 `name` 一项后面写上你在 GitHub Profile 中填写的 Name，在 `email` 一项后面写上注册 GitHub 时候使用的邮箱。
@@ -96,6 +97,7 @@ QQ 群的时效性、随意性较强，难以翻查每个人提出的意见，�
 [core]
 	editor = code --wait
 	safecrlf = true
+	quotepath = false
 [alias]
 	lg = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
 ```
@@ -105,7 +107,7 @@ QQ 群的时效性、随意性较强，难以翻查每个人提出的意见，�
 以文档库为例：
 
 1. 使用浏览器打开宝琛 GitHub 账户下的 [文档库](https://github.com/c-rainstorm/OnlineShoppingSystem-Documents)，点击右上角 Fork，将文档库 fork 到自己的 GitHub 账户下。
-1. 在你喜欢的本地位置，新建文件夹 `doc`。使用『右键 -> Git Bash Here』，进入 Git Bash，运行以下命令：
+1. 在你喜欢的本地位置，使用『右键 -> Git Bash Here』，进入 Git Bash，运行以下命令：
 
 	> $ git clone -o trunk https://github.com/c-rainstorm/OnlineShoppingSystem-Documents doc
 
@@ -113,7 +115,7 @@ QQ 群的时效性、随意性较强，难以翻查每个人提出的意见，�
 
 	> $ git remote add myfork {your-github-fork-address}
 
-代码库在本地要使用 eclipse workspace 下的 src 文件夹。
+代码库在本地要使用 eclipse workspace 下的 src 文件夹，即将 clone 命令最后一个参数 `doc` 改为 `src`。
 
 在前期准备工作完成以后就可以在『建立新分支 -> 在分支上工作 -> 发起 pull request -> 更新 pull request -> 删除分支』的工作流上循环了。如果你对 Git 了解不深，请严格按照工作流顺序执行，否则可能出现自己无法解决的问题。
 
@@ -125,8 +127,10 @@ QQ 群的时效性、随意性较强，难以翻查每个人提出的意见，�
 
 1. 你已经完成手头所有工作，当前工作目录干净，当前分支为 master，与远程文档、代码总仓库同步情况未知。
 
-	此时，使用下面的命令同步本地 master 分支和建立新分支：
+	此时，**顺序执行**下面的命令同步本地 master 分支和建立新分支：
 
+	> 关闭你所有的文档代码编辑器
+	>
 	> $ git fetch trunk
 	>
 	> $ git rebase trunk/master master
@@ -135,8 +139,10 @@ QQ 群的时效性、随意性较强，难以翻查每个人提出的意见，�
 
 1. 你正工作在另一个分支上，当前工作目录保存着你正在工作的内容，当前分支不是 master，与远程文档、代码总仓库同步情况未知。
 
-	此时，使用下面的命令同步本地 master 分支和建立新分支：
+	此时，**顺序执行**下面的命令同步本地 master 分支和建立新分支：
 
+	> 关闭你所有的文档代码编辑器
+	>
 	> $ git commit -a -m "切换分支，临时保存"  # 如果当前工作目录不干净
 	>
 	> $ git fetch trunk
@@ -173,8 +179,10 @@ QQ 群的时效性、随意性较强，难以翻查每个人提出的意见，�
 
 ###  2.4. <a name='PullRequest-10'></a>发起 Pull Request
 
-你在分支上工作这一段时间里，其他人或已经向总仓库提交了更改，导致本地分支与远程 trunk/master 分支不同步。在实际发起 pull request 前，执行以下命令，使本地与远程两 master 分支同步，使正工作的分支与远程 trunk/master 分支同步。
+你在分支上工作这一段时间里，其他人或已经向总仓库提交了更改，导致本地分支与远程 trunk/master 分支不同步。在实际发起 pull request 前，顺序执行以下命令，使本地与远程两 master 分支同步，使正工作的分支与远程 trunk/master 分支同步。
 
+> 关闭你所有的文档代码编辑器
+>
 > $ git fetch trunk
 >
 > $ git rebase trunk/master master
@@ -191,8 +199,10 @@ QQ 群的时效性、随意性较强，难以翻查每个人提出的意见，�
 
 修改推送到 GitHub 之后，要经过代码审查与讨论，才可以被合并入总仓库。这个时候组内的其他人可以对你的代码进行讨论和评价。这个阶段，大家可能会发现你的 pull request 存在问题。
 
-如果你决定修改这个 pull request，而你现在本地仓库不在这个分支上，使用如下命令切换到 pull request 对应的分支：
+如果你决定修改这个 pull request，而你现在本地仓库不在这个分支上，**顺序执行**以下命令切换到 pull request 对应的分支：
 
+> 关闭你所有的文档代码编辑器
+>
 > $ git commit -a -m "切换分支，临时保存"  # 如果当前工作目录不干净
 >
 > $ git checkout {branch-to-be-revised}
@@ -209,7 +219,7 @@ QQ 群的时效性、随意性较强，难以翻查每个人提出的意见，�
 >
 > $ git push myfork {revised-branch}
 
-注意：当且仅当 pull request 处于打开状态下才可以对 pull request 进行更新。pull request 的状态在 GitHub 总仓库对应页面上。
+注意：当且仅当 pull request 处于打开状态下才可以对 pull request 进行更新。Pull request 的状态在 GitHub 总仓库对应页面上可以看到。
 
 ###  2.6. <a name='-12'></a>删除分支
 
@@ -217,7 +227,13 @@ pull request 被关闭的时候，对应分支的生命周期就结束了。一�
 
 > $ git branch -D {expired-branch}
 
-并在自己 GitHub 账户下手动删除分支。以：
+并在自己 GitHub 账户下手动删除分支
+
+最后后，再在本地运行以下命令删除本地已过期的 remote-tracking branches。
+
+> $ git remote prune myfork
+
+以：
 
 - 保持本地与 GitHub 仓库分支处于可控状态。
 - 避免出现 pull request 已经关闭了，自己仍对其相应分支进行编辑的情况。
@@ -281,7 +297,7 @@ GitHub 提供三种网页合并方式：
 1. 同步 master 分支。由于有两人对 trunk 进行管理，可能导致自己本地与 trunk 两 master 分支不同步。
 1. 重写分支的 commit。在进行重写前，最好先保持 commit log 和 message 不变，只先将其 rebase 到 master 分支上，以尽早发现可能存在的冲突问题。
 
-    1. 确定要重写的范围（Pro Git section 7.1）：切换到相应分支，使用命令 `git log master..HEAD` 确定不在 master 分支上，但在当前分支上的 commits。
+	1. 确定要重写的范围（Pro Git section 7.1）：切换到相应分支，使用命令 `git log master..HEAD` 确定不在 master 分支上，但在当前分支上的 commits。
 	1. 重写 commit（Pro Git section 7.6）：重写 commit 时，为保留 PR 的原作者，避免使用 `reset` 工具，而使用 `rebase -i master` 将 PR 重写为一个或若干个 commits，并重写 commit message。
 
 1. 转移 commit 到 master。`rebase` 或者 `merge` 皆可。注意不要让 Git 生成没有实际内容的空白 commit，造成菱形的 log。
@@ -318,7 +334,7 @@ GitHub 提供三种网页合并方式：
 	- 错误：『Fix：更新了 \`HTTP 详解\` 的链接』、『New：新增管理 PR 的章节』。
 
 1. 使用陈诉式的动词，
-    - 正确：『更新』、『增强』、『修改』，
+	- 正确：『更新』、『增强』、『修改』，
 	- 错误：『更新了』、『增强了』、『修改了』。
 
 **后缀**：


### PR DESCRIPTION
- 引用 廖雪峰关于生成和添加 SSH key 的章节
- 解决 Windows 下 git status 乱码问题
- 解决 初始化本地仓库时 doc 文件夹套 doc 文件夹问题
- 添加 每次切换分支前关闭编辑器的步骤
- 添加 删除本地与 GitHub 分支时要 remote prune 的步骤
- 修复 混合使用的空格和 tab 问题
- 修复 一些 typo
